### PR TITLE
Set up Jest with basic component tests

### DIFF
--- a/client/jest.config.ts
+++ b/client/jest.config.ts
@@ -1,0 +1,15 @@
+import nextJest from 'next/jest'
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jest-environment-jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+}
+
+export default createJestConfig(customConfig)

--- a/client/jest.setup.ts
+++ b/client/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",
@@ -45,6 +46,11 @@
     "prettier-plugin-tailwindcss": "^0.6.8",
     "tailwind-merge": "^2.5.3",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/user-event": "^14.4.3",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/client/src/app/projects/BoardView/__tests__/BoardView.test.tsx
+++ b/client/src/app/projects/BoardView/__tests__/BoardView.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import BoardView from '../index'
+
+jest.mock('@/state/api', () => ({
+  useGetTasksQuery: () => ({ data: [], isLoading: false, error: null }),
+  useUpdateTaskStatusMutation: () => [jest.fn()],
+}))
+
+it('renders board columns', () => {
+  render(<BoardView id="1" setIsModalNewTaskOpen={() => {}} />)
+  expect(screen.getByText('To Do')).toBeInTheDocument()
+})

--- a/client/src/app/projects/ListView/__tests__/ListView.test.tsx
+++ b/client/src/app/projects/ListView/__tests__/ListView.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import ListView from '../index'
+
+jest.mock('@/state/api', () => ({
+  useGetTasksQuery: () => ({ data: [], isLoading: false, error: null }),
+}))
+
+test('shows header', () => {
+  render(<ListView id="1" setIsModalNewTaskOpen={() => {}} />)
+  expect(screen.getByText('List')).toBeInTheDocument()
+})

--- a/client/src/app/projects/ModalDeleteProject/__tests__/ModalDeleteProject.test.tsx
+++ b/client/src/app/projects/ModalDeleteProject/__tests__/ModalDeleteProject.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import ModalDeleteProject from '../index'
+
+it('shows confirmation text', () => {
+  render(
+    <ModalDeleteProject isOpen={true} onClose={() => {}} />
+  )
+  expect(screen.getByText(/delete this project/i)).toBeInTheDocument()
+})

--- a/client/src/app/projects/ModalNewProject/__tests__/ModalNewProject.test.tsx
+++ b/client/src/app/projects/ModalNewProject/__tests__/ModalNewProject.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import ModalNewProject from '../index'
+
+it('renders project form when open', () => {
+  render(
+    <ModalNewProject isOpen={true} onClose={() => {}} />
+  )
+  expect(screen.getByPlaceholderText('Project Name')).toBeInTheDocument()
+})

--- a/client/src/app/projects/TableView/__tests__/TableView.test.tsx
+++ b/client/src/app/projects/TableView/__tests__/TableView.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import TableView from '../index'
+
+jest.mock('@/state/api', () => ({
+  useGetTasksQuery: () => ({ data: [], isLoading: false, error: null }),
+}))
+
+test('shows header name', () => {
+  render(<TableView id="1" setIsModalNewTaskOpen={() => {}} />)
+  expect(screen.getByText('Table')).toBeInTheDocument()
+})

--- a/client/src/app/projects/TimelineView/__tests__/TimelineView.test.tsx
+++ b/client/src/app/projects/TimelineView/__tests__/TimelineView.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import TimelineView from '../index'
+
+jest.mock('@/state/api', () => ({
+  useGetTasksQuery: () => ({ data: [], isLoading: false, error: null }),
+}))
+
+test('renders button', () => {
+  render(<TimelineView id="1" setIsModalNewTaskOpen={() => {}} />)
+  expect(screen.getByRole('button', { name: /add new task/i })).toBeInTheDocument()
+})

--- a/client/src/components/Header/__tests__/Header.test.tsx
+++ b/client/src/components/Header/__tests__/Header.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react'
+import Header from '../index'
+
+it('shows provided name', () => {
+  render(<Header name="My Header" />)
+  expect(screen.getByText('My Header')).toBeInTheDocument()
+})

--- a/client/src/components/Modal/__tests__/Modal.test.tsx
+++ b/client/src/components/Modal/__tests__/Modal.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import Modal from '../index'
+
+it('renders children when open', () => {
+  render(
+    <Modal isOpen={true} onClose={() => {}} name="Test Modal">
+      <div>modal content</div>
+    </Modal>
+  )
+  expect(screen.getByText('modal content')).toBeInTheDocument()
+})

--- a/client/src/components/ModalNewTask/__tests__/ModalNewTask.test.tsx
+++ b/client/src/components/ModalNewTask/__tests__/ModalNewTask.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import ModalNewTask from '../index'
+
+it('renders task form when open', () => {
+  render(
+    <ModalNewTask isOpen={true} onClose={() => {}} />
+  )
+  expect(screen.getByPlaceholderText('Title')).toBeInTheDocument()
+})

--- a/client/src/components/Navbar/__tests__/Navbar.test.tsx
+++ b/client/src/components/Navbar/__tests__/Navbar.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/app/redux'
+import Navbar from '../index'
+
+it('toggles dark mode', () => {
+  const store = makeStore()
+  render(
+    <Provider store={store}>
+      <Navbar />
+    </Provider>
+  )
+  const toggle = screen.getAllByRole('button')[0]
+  fireEvent.click(toggle)
+  expect(store.getState().global.isDarkMode).toBe(true)
+})

--- a/client/src/components/ProjectCard/__tests__/ProjectCard.test.tsx
+++ b/client/src/components/ProjectCard/__tests__/ProjectCard.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react'
+import ProjectCard from '../index'
+
+it('renders project name', () => {
+  const project = { id: 1, name: 'Test', description: '', startDate: '', endDate: '' }
+  render(<ProjectCard project={project as any} />)
+  expect(screen.getByText(/Test/)).toBeInTheDocument()
+})

--- a/client/src/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/client/src/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/app/redux'
+import Sidebar from '../index'
+
+it('collapses sidebar', () => {
+  const store = makeStore()
+  render(
+    <Provider store={store}>
+      <Sidebar />
+    </Provider>
+  )
+  const closeButtons = screen.getAllByRole('button')
+  if(closeButtons.length > 0){
+    fireEvent.click(closeButtons[closeButtons.length-1])
+  }
+  expect(store.getState().global.isSidebarCollapsed).toBe(true)
+})

--- a/client/src/components/TaskCard/__tests__/TaskCard.test.tsx
+++ b/client/src/components/TaskCard/__tests__/TaskCard.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react'
+import TaskCard from '../index'
+
+it('renders task title', () => {
+  const task = { id: 1, title: 'Task', description: '', status: '', priority: '', tags: '', startDate: '', dueDate: '', author: null, assignee: null }
+  render(<TaskCard task={task as any} />)
+  expect(screen.getByText(/Task/)).toBeInTheDocument()
+})

--- a/client/src/components/UserCard/__tests__/UserCard.test.tsx
+++ b/client/src/components/UserCard/__tests__/UserCard.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react'
+import UserCard from '../index'
+
+it('shows username', () => {
+  const user = { id:1, username:'john', email:'a', profilePictureUrl:'', teamId:null }
+  render(<UserCard user={user as any} />)
+  expect(screen.getByText(/john/)).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- set up Jest config using `next/jest`
- add `test` script and testing dev dependencies
- write example RTL tests for components

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845cfa47a1483289d9a00a259aac306